### PR TITLE
Fix wrong year in caution notice

### DIFF
--- a/hardware/pcb/README.md
+++ b/hardware/pcb/README.md
@@ -3,7 +3,7 @@
 Electronic schematics and wiring diagrams for the Sesame Distro Board, a custom PCB just for the Sesame Robot Project. The distro boar pairs with the ESP32-DevKitC-32E.
 
 > [!CAUTION]  
-> UPDATE 1/20/25: Upon further testing, the Sesame distro board V1 will work, but it has a few issues that make it a little harder to assemble and will not run on teathered power (eg. USB C). Until V2 is released, I recommend using the S2 Mini / Hand Wiring approach. If you ordered a distro board V1, it will still be supported with wiring guides and firmware, and will still work on battery power.
+> UPDATE 1/20/26: Upon further testing, the Sesame distro board V1 will work, but it has a few issues that make it a little harder to assemble and will not run on teathered power (eg. USB C). Until V2 is released, I recommend using the S2 Mini / Hand Wiring approach. If you ordered a distro board V1, it will still be supported with wiring guides and firmware, and will still work on battery power.
 
 
 **PCBway Sponsorship**


### PR DESCRIPTION
I noticed the wrong year in the caution notice while reading the documentation.

