### PR TITLE
Name aliases for servos, useable in webapi and enforced in Studio

### DIFF
--- a/firmware/movement-sequences.h
+++ b/firmware/movement-sequences.h
@@ -2,6 +2,33 @@
 
 #include <Arduino.h>
 
+enum ServoName : uint_8t {
+  R1 = 0, 
+  R2 = 1,
+  L1 = 2,
+  L2 = 3,
+  R4 = 4,
+  R3 = 5,
+  L3 = 6,
+  L4 = 7
+};
+
+const String[] ServoNames=["R1","R2","L1","L2","R4","R3","L3","L4"];
+
+inline int servoNameToIndex(String servo) {
+  switch(servo) {
+    case "L1": return L1;
+    case "L2": return L2;
+    case "L3": return L3;
+    case "L4": return L4;
+    case "R1": return R1;
+    case "R2": return R2;
+    case "R3": return R3;
+    case "R4": return R4;
+  }
+  return -1;
+}
+
 enum FaceAnimMode : uint8_t {
   FACE_ANIM_LOOP = 0,
   FACE_ANIM_ONCE = 1,
@@ -52,14 +79,14 @@ inline void runRestPose() {
 inline void runStandPose(int face) { 
   Serial.println(F("STAND")); 
   if (face == 1) setFaceWithMode("stand", FACE_ANIM_ONCE); 
-  setServoAngle(0, 135); 
-  setServoAngle(1, 45); 
-  setServoAngle(2, 45); 
-  setServoAngle(3, 135); 
-  setServoAngle(4, 0); 
-  setServoAngle(5, 180); 
-  setServoAngle(6, 0); 
-  setServoAngle(7, 180); 
+  setServoAngle(R1, 135); 
+  setServoAngle(R2, 45); 
+  setServoAngle(L1, 45); 
+  setServoAngle(L2, 135); 
+  setServoAngle(R4, 0); 
+  setServoAngle(R3, 180); 
+  setServoAngle(L3, 0); 
+  setServoAngle(L4, 180); 
   if (face == 1) enterIdle();
 }
 
@@ -68,14 +95,14 @@ inline void runWavePose() {
   setFaceWithMode("wave", FACE_ANIM_ONCE); 
   runStandPose(0); 
   delayWithFace(200);
-  setServoAngle(4, 80); setServoAngle(6, 180); 
-  setServoAngle(3, 60); setServoAngle(0, 100); 
+  setServoAngle(R4, 80); setServoAngle(L3, 180); 
+  setServoAngle(L2, 60); setServoAngle(R1, 100); 
   delayWithFace(200);
-  setServoAngle(6, 180); 
+  setServoAngle(L3, 180); 
   delayWithFace(300); 
   for (int i = 0; i < 4; i++) { 
-    setServoAngle(6, 180); delayWithFace(300); 
-    setServoAngle(6, 100); delayWithFace(300); 
+    setServoAngle(L3, 180); delayWithFace(300); 
+    setServoAngle(L3, 100); delayWithFace(300); 
   } 
   runStandPose(1); 
   if (currentCommand == "wave") currentCommand = "";
@@ -84,17 +111,17 @@ inline void runWavePose() {
 inline void runDancePose() { 
   Serial.println(F("DANCE")); 
   setFaceWithMode("dance", FACE_ANIM_LOOP); 
-  setServoAngle(0, 90); setServoAngle(1, 90); 
-  setServoAngle(2, 90); setServoAngle(3, 90); 
-  setServoAngle(4, 160); setServoAngle(5, 160); 
-  setServoAngle(6, 10); setServoAngle(7, 10); 
+  setServoAngle(R1, 90); setServoAngle(R2, 90); 
+  setServoAngle(L1, 90); setServoAngle(L2, 90); 
+  setServoAngle(R4, 160); setServoAngle(R3, 160); 
+  setServoAngle(L3, 10); setServoAngle(L4, 10); 
   delayWithFace(300); 
   for (int i = 0; i < 5; i++) { 
-    setServoAngle(4, 115); setServoAngle(5, 115); 
-    setServoAngle(6, 10); setServoAngle(7, 10); 
+    setServoAngle(R4, 115); setServoAngle(R3, 115); 
+    setServoAngle(L3, 10); setServoAngle(L4, 10); 
     delayWithFace(300); 
-    setServoAngle(4, 160); setServoAngle(5, 160); 
-    setServoAngle(6, 65); setServoAngle(7, 65); 
+    setServoAngle(R4, 160); setServoAngle(R3, 160); 
+    setServoAngle(L3, 65); setServoAngle(L4, 65); 
     delayWithFace(300); 
   } 
   runStandPose(1); 
@@ -106,11 +133,11 @@ inline void runSwimPose() {
   setFaceWithMode("swim", FACE_ANIM_ONCE); 
   for (int i = 0; i < 8; i++) setServoAngle(i, 90); 
   for (int i = 0; i < 4; i++) { 
-    setServoAngle(0, 135); setServoAngle(1, 45); 
-    setServoAngle(2, 45); setServoAngle(3, 135); 
+    setServoAngle(R1, 135); setServoAngle(R2, 45); 
+    setServoAngle(L1, 45); setServoAngle(L2, 135); 
     delayWithFace(400); 
-    setServoAngle(0, 90); setServoAngle(1, 90); 
-    setServoAngle(2, 90); setServoAngle(3, 90); 
+    setServoAngle(R1, 90); setServoAngle(R2, 90); 
+    setServoAngle(L1, 90); setServoAngle(L2, 90); 
     delayWithFace(400); 
   } 
   runStandPose(1); 
@@ -120,10 +147,10 @@ inline void runSwimPose() {
 inline void runPointPose() { 
   Serial.println(F("POINT")); 
   setFaceWithMode("point", FACE_ANIM_BOOMERANG); 
-  setServoAngle(3, 60); setServoAngle(0, 135); 
-  setServoAngle(1, 100); setServoAngle(7, 180); 
-  setServoAngle(2, 25); setServoAngle(6, 145);
-  setServoAngle(4, 80); setServoAngle(5, 170); 
+  setServoAngle(L2, 60); setServoAngle(R1, 135); 
+  setServoAngle(R2, 100); setServoAngle(L4, 180); 
+  setServoAngle(L1, 25); setServoAngle(L3, 145);
+  setServoAngle(R4, 80); setServoAngle(R3, 170); 
   delayWithFace(2000); 
   runStandPose(1); 
   if (currentCommand == "point") currentCommand = "";
@@ -134,17 +161,17 @@ inline void runPushupPose() {
   setFaceWithMode("pushup", FACE_ANIM_ONCE);
   runStandPose(0); 
   delayWithFace(200);
-  setServoAngle(2, 0);
-  setServoAngle(0, 180);
-  setServoAngle(6, 90);
-  setServoAngle(5, 90);
+  setServoAngle(L1, 0);
+  setServoAngle(R1, 180);
+  setServoAngle(L3, 90);
+  setServoAngle(R3, 90);
   delayWithFace(500);
   for (int i = 0; i < 4; i++) {
-    setServoAngle(6, 0);
-    setServoAngle(5, 180);
+    setServoAngle(L3, 0);
+    setServoAngle(R3, 180);
     delayWithFace(600);
-    setServoAngle(6, 90);
-    setServoAngle(5, 90);
+    setServoAngle(L3, 90);
+    setServoAngle(R3, 90);
     delayWithFace(500);
   }
   runStandPose(1);
@@ -156,17 +183,17 @@ inline void runBowPose() {
   setFaceWithMode("bow", FACE_ANIM_ONCE);
   runStandPose(0); 
   delayWithFace(200);
-  setServoAngle(2, 0);
-  setServoAngle(0, 180);
-  setServoAngle(6, 0);
-  setServoAngle(5, 180);
-  setServoAngle(3, 180);
-  setServoAngle(1, 0);
-  setServoAngle(4, 0);
-  setServoAngle(7, 180);
+  setServoAngle(L1, 0);
+  setServoAngle(R1, 180);
+  setServoAngle(L3, 0);
+  setServoAngle(R3, 180);
+  setServoAngle(L2, 180);
+  setServoAngle(R2, 0);
+  setServoAngle(R4, 0);
+  setServoAngle(L4, 180);
   delayWithFace(600);
-  setServoAngle(6, 90);
-  setServoAngle(5, 90);
+  setServoAngle(L3, 90);
+  setServoAngle(R3, 90);
   delayWithFace(3000);
   runStandPose(1);
   if (currentCommand == "bow") currentCommand = "";
@@ -177,22 +204,22 @@ inline void runCutePose() {
   setFaceWithMode("cute", FACE_ANIM_ONCE);
   runStandPose(0); 
   delayWithFace(200);
-  setServoAngle(3, 160);
-  setServoAngle(1, 20);
-  setServoAngle(4, 180);
-  setServoAngle(7, 0);
+  setServoAngle(L2, 160);
+  setServoAngle(R2, 20);
+  setServoAngle(R4, 180);
+  setServoAngle(L4, 0);
 
-  setServoAngle(2, 0);
-  setServoAngle(0, 180);
-  setServoAngle(6, 180);
-  setServoAngle(5, 0);
+  setServoAngle(L1, 0);
+  setServoAngle(R1, 180);
+  setServoAngle(L3, 180);
+  setServoAngle(R3, 0);
   delayWithFace(200);
   for (int i = 0; i < 5; i++) {
-    setServoAngle(4, 180);
-    setServoAngle(7, 45);
+    setServoAngle(R4, 180);
+    setServoAngle(L4, 45);
     delayWithFace(300);
-    setServoAngle(4, 135);
-    setServoAngle(7, 0);
+    setServoAngle(R4, 135);
+    setServoAngle(L4, 0);
     delayWithFace(300);
   }
   runStandPose(1);
@@ -204,17 +231,17 @@ inline void runFreakyPose() {
   setFaceWithMode("freaky", FACE_ANIM_ONCE);
   runStandPose(0); 
   delayWithFace(200);
-  setServoAngle(2, 0);
-  setServoAngle(0, 180);
-  setServoAngle(3, 180);
-  setServoAngle(1, 0);
-  setServoAngle(4, 90);
-  setServoAngle(5, 0);
+  setServoAngle(L1, 0);
+  setServoAngle(R1, 180);
+  setServoAngle(L2, 180);
+  setServoAngle(R2, 0);
+  setServoAngle(R4, 90);
+  setServoAngle(R3, 0);
   delayWithFace(200);
   for (int i = 0; i < 3; i++) {
-    setServoAngle(5, 25);
+    setServoAngle(R3, 25);
     delayWithFace(400);
-    setServoAngle(5, 0);
+    setServoAngle(R3, 0);
     delayWithFace(400);
   }
   runStandPose(1);
@@ -226,13 +253,13 @@ inline void runWormPose() {
   setFaceWithMode("worm", FACE_ANIM_ONCE);
   runStandPose(0);
   delayWithFace(200);
-  setServoAngle(0, 180); setServoAngle(1, 0); setServoAngle(2, 0); setServoAngle(3, 180);
-  setServoAngle(4, 90); setServoAngle(5, 90); setServoAngle(6, 90); setServoAngle(7, 90);
+  setServoAngle(R1, 180); setServoAngle(R2, 0); setServoAngle(L1, 0); setServoAngle(L2, 180);
+  setServoAngle(R4, 90); setServoAngle(R3, 90); setServoAngle(L3, 90); setServoAngle(L4, 90);
   delayWithFace(200);
   for(int i=0; i<5; i++) {
-    setServoAngle(5, 45); setServoAngle(6, 135); setServoAngle(4, 45); setServoAngle(7, 135);
+    setServoAngle(R3, 45); setServoAngle(L3, 135); setServoAngle(R4, 45); setServoAngle(L4, 135);
     delayWithFace(300);
-    setServoAngle(5, 135); setServoAngle(6, 45); setServoAngle(4, 135); setServoAngle(7, 45);
+    setServoAngle(R3, 135); setServoAngle(L3, 45); setServoAngle(R4, 135); setServoAngle(L4, 45);
     delayWithFace(300);
   }
   runStandPose(1);
@@ -244,13 +271,13 @@ inline void runShakePose() {
   setFaceWithMode("shake", FACE_ANIM_ONCE);
   runStandPose(0);
   delayWithFace(200);
-  setServoAngle(0, 135); setServoAngle(2, 45); setServoAngle(6, 90); setServoAngle(5, 90);
-  setServoAngle(3, 90); setServoAngle(1, 90);
+  setServoAngle(R1, 135); setServoAngle(L1, 45); setServoAngle(L3, 90); setServoAngle(R3, 90);
+  setServoAngle(L2, 90); setServoAngle(R2, 90);
   delayWithFace(200);
   for(int i=0; i<5; i++) {
-    setServoAngle(4, 45); setServoAngle(7, 135);
+    setServoAngle(R4, 45); setServoAngle(L4, 135);
     delayWithFace(300);
-    setServoAngle(4, 0); setServoAngle(7, 180);
+    setServoAngle(R4, 0); setServoAngle(L4, 180);
     delayWithFace(300);
   }
   runStandPose(1);
@@ -262,10 +289,10 @@ inline void runShrugPose() {
   runStandPose(0);
   setFaceWithMode("dead", FACE_ANIM_ONCE);
   delayWithFace(200);
-  setServoAngle(5, 90); setServoAngle(4, 90); setServoAngle(6, 90); setServoAngle(7, 90);
+  setServoAngle(R3, 90); setServoAngle(R4, 90); setServoAngle(L3, 90); setServoAngle(L4, 90);
   delayWithFace(1000);
   setFaceWithMode("shrug", FACE_ANIM_ONCE);
-  setServoAngle(5, 0); setServoAngle(4, 180); setServoAngle(6, 180); setServoAngle(7, 0);
+  setServoAngle(R3, 0); setServoAngle(R4, 180); setServoAngle(L3, 180); setServoAngle(L4, 0);
   delayWithFace(1500);
   runStandPose(1);
   if (currentCommand == "shrug") currentCommand = "";
@@ -276,7 +303,7 @@ inline void runDeadPose() {
   runStandPose(0);
   setFaceWithMode("dead", FACE_ANIM_BOOMERANG);
   delayWithFace(200);
-  setServoAngle(5, 90); setServoAngle(4, 90); setServoAngle(6, 90); setServoAngle(7, 90);
+  setServoAngle(R3, 90); setServoAngle(R4, 90); setServoAngle(L3, 90); setServoAngle(L4, 90);
   if (currentCommand == "dead") currentCommand = "";
 }
 
@@ -285,12 +312,12 @@ inline void runCrabPose() {
   setFaceWithMode("crab", FACE_ANIM_ONCE);
   runStandPose(0);
   delayWithFace(200);
-  setServoAngle(0, 90); setServoAngle(1, 90); setServoAngle(2, 90); setServoAngle(3, 90);
-  setServoAngle(4, 0); setServoAngle(5, 180); setServoAngle(6, 45); setServoAngle(7, 135);
+  setServoAngle(R1, 90); setServoAngle(R2, 90); setServoAngle(L1, 90); setServoAngle(L2, 90);
+  setServoAngle(R4, 0); setServoAngle(R3, 180); setServoAngle(L3, 45); setServoAngle(L4, 135);
   for(int i=0; i<5; i++) {
-    setServoAngle(4, 45); setServoAngle(5, 135); setServoAngle(6, 0); setServoAngle(7, 180);
+    setServoAngle(R4, 45); setServoAngle(R3, 135); setServoAngle(L3, 0); setServoAngle(L4, 180);
     delayWithFace(300);
-    setServoAngle(4, 0); setServoAngle(5, 180); setServoAngle(6, 45); setServoAngle(7, 135);
+    setServoAngle(R4, 0); setServoAngle(R3, 180); setServoAngle(L3, 45); setServoAngle(L4, 135);
     delayWithFace(300);
   }
   runStandPose(1);
@@ -302,24 +329,24 @@ inline void runWalkPose() {
   Serial.println(F("WALK FWD"));
   setFaceWithMode("walk", FACE_ANIM_ONCE);
   // Initial Step
-  setServoAngle(5, 135); setServoAngle(6, 45);
-  setServoAngle(1, 100); setServoAngle(2, 25);
+  setServoAngle(R3, 135); setServoAngle(L3, 45);
+  setServoAngle(R2, 100); setServoAngle(L1, 25);
   if (!pressingCheck("forward", frameDelay)) return;
   
   for (int i = 0; i < walkCycles; i++) {
-    setServoAngle(5, 135); setServoAngle(6, 0);
+    setServoAngle(R3, 135); setServoAngle(L3, 0);
     if (!pressingCheck("forward", frameDelay)) return;
-    setServoAngle(7, 135); setServoAngle(3, 90);
-    setServoAngle(4, 0); setServoAngle(0, 180);
+    setServoAngle(L4, 135); setServoAngle(L2, 90);
+    setServoAngle(R4, 0); setServoAngle(R1, 180);
     if (!pressingCheck("forward", frameDelay)) return;    
-    setServoAngle(1, 45); setServoAngle(2, 90);
+    setServoAngle(R2, 45); setServoAngle(L1, 90);
     if (!pressingCheck("forward", frameDelay)) return;
-    setServoAngle(4, 45); setServoAngle(7, 180);
+    setServoAngle(R4, 45); setServoAngle(L4, 180);
     if (!pressingCheck("forward", frameDelay)) return;
-    setServoAngle(5, 180); setServoAngle(6, 45);
-    setServoAngle(1, 90); setServoAngle(2, 0);
+    setServoAngle(R3, 180); setServoAngle(L3, 45);
+    setServoAngle(R2, 90); setServoAngle(L1, 0);
     if (!pressingCheck("forward", frameDelay)) return;  
-    setServoAngle(3, 135); setServoAngle(0, 90);
+    setServoAngle(L2, 135); setServoAngle(R1, 90);
     if (!pressingCheck("forward", frameDelay)) return;
   }
   runStandPose(1);
@@ -332,19 +359,19 @@ inline void runWalkBackward() {
   if (!pressingCheck("backward", frameDelay)) return;
   
   for (int i = 0; i < walkCycles; i++) {
-    setServoAngle(5, 135); setServoAngle(6, 0);
+    setServoAngle(R3, 135); setServoAngle(L3, 0);
     if (!pressingCheck("backward", frameDelay)) return;
-    setServoAngle(7, 135); setServoAngle(3, 135);
-    setServoAngle(4, 0); setServoAngle(0, 90);
+    setServoAngle(L4, 135); setServoAngle(L2, 135);
+    setServoAngle(R4, 0); setServoAngle(R1, 90);
     if (!pressingCheck("backward", frameDelay)) return;    
-    setServoAngle(1, 90); setServoAngle(2, 0);
+    setServoAngle(R2, 90); setServoAngle(L1, 0);
     if (!pressingCheck("backward", frameDelay)) return;
-    setServoAngle(4, 45); setServoAngle(7, 180);
+    setServoAngle(R4, 45); setServoAngle(L4, 180);
     if (!pressingCheck("backward", frameDelay)) return;
-    setServoAngle(5, 180); setServoAngle(6, 45);
-    setServoAngle(1, 45); setServoAngle(2, 90);
+    setServoAngle(R3, 180); setServoAngle(L3, 45);
+    setServoAngle(R2, 45); setServoAngle(L1, 90);
     if (!pressingCheck("backward", frameDelay)) return;  
-    setServoAngle(3, 90); setServoAngle(0, 180);
+    setServoAngle(L2, 90); setServoAngle(R1, 180);
     if (!pressingCheck("backward", frameDelay)) return;
   }
   runStandPose(1);
@@ -356,22 +383,22 @@ inline void runTurnLeft() {
   setFaceWithMode("walk", FACE_ANIM_ONCE);
   for (int i = 0; i < walkCycles; i++) {
     //legset 1 (R1 L2)
-    setServoAngle(5, 135); setServoAngle(7, 135); 
+    setServoAngle(R3, 135); setServoAngle(L4, 135); 
     if (!pressingCheck("left", frameDelay)) return;
-    setServoAngle(0, 180); setServoAngle(3, 180); 
+    setServoAngle(R1, 180); setServoAngle(L2, 180); 
     if (!pressingCheck("left", frameDelay)) return;
-    setServoAngle(5, 180); setServoAngle(7, 180); 
+    setServoAngle(R3, 180); setServoAngle(L4, 180); 
     if (!pressingCheck("left", frameDelay)) return;
-    setServoAngle(0, 135); setServoAngle(3, 135);
+    setServoAngle(R1, 135); setServoAngle(L2, 135);
     if (!pressingCheck("left", frameDelay)) return;
       //legset 2 (R2 L1)
-    setServoAngle(4, 45); setServoAngle(6, 45); 
+    setServoAngle(R4, 45); setServoAngle(L3, 45); 
     if (!pressingCheck("left", frameDelay)) return;
-    setServoAngle(1, 90); setServoAngle(2, 90); 
+    setServoAngle(R2, 90); setServoAngle(L1, 90); 
     if (!pressingCheck("left", frameDelay)) return;
-    setServoAngle(4, 0); setServoAngle(6, 0); 
+    setServoAngle(R4, 0); setServoAngle(L3, 0); 
     if (!pressingCheck("left", frameDelay)) return;
-    setServoAngle(1, 45); setServoAngle(2, 45);
+    setServoAngle(R2, 45); setServoAngle(L1, 45);
     if (!pressingCheck("left", frameDelay)) return;  
   }
   runStandPose(1);
@@ -382,22 +409,22 @@ inline void runTurnRight() {
   setFaceWithMode("walk", FACE_ANIM_ONCE);
   for (int i = 0; i < walkCycles; i++) {
     //legset 2 (R2 L1)
-    setServoAngle(4, 45); setServoAngle(6, 45); 
+    setServoAngle(R4, 45); setServoAngle(L3, 45); 
     if (!pressingCheck("right", frameDelay)) return;
-    setServoAngle(1, 0); setServoAngle(2, 0); 
+    setServoAngle(R2, 0); setServoAngle(L1, 0); 
     if (!pressingCheck("right", frameDelay)) return;
-    setServoAngle(4, 0); setServoAngle(6, 0); 
+    setServoAngle(R4, 0); setServoAngle(L3, 0); 
     if (!pressingCheck("right", frameDelay)) return;
-    setServoAngle(1, 45); setServoAngle(2, 45);
+    setServoAngle(R2, 45); setServoAngle(L1, 45);
     if (!pressingCheck("right", frameDelay)) return;  
     //legset 1 (R1 L2)
-    setServoAngle(5, 135); setServoAngle(7, 135); 
+    setServoAngle(R3, 135); setServoAngle(L4, 135); 
     if (!pressingCheck("right", frameDelay)) return;
-    setServoAngle(0, 90); setServoAngle(3, 90); 
+    setServoAngle(R1, 90); setServoAngle(L2, 90); 
     if (!pressingCheck("right", frameDelay)) return;
-    setServoAngle(5, 180); setServoAngle(7, 180); 
+    setServoAngle(R3, 180); setServoAngle(L4, 180); 
     if (!pressingCheck("right", frameDelay)) return;
-    setServoAngle(0, 135); setServoAngle(3, 135);
+    setServoAngle(R1, 135); setServoAngle(L2, 135);
     if (!pressingCheck("right", frameDelay)) return;
   }
   runStandPose(1);

--- a/firmware/sesame-firmware-main.ino
+++ b/firmware/sesame-firmware-main.ino
@@ -178,9 +178,14 @@ void handleCommandWeb() {
   }
   else if (server.hasArg("motor") && server.hasArg("value")) {
     int motorNum = server.arg("motor").toInt();
+    int servoIdx = servoNameToIndex(server.arg("motor"));
     int angle = server.arg("value").toInt();
     if (motorNum >= 1 && motorNum <= 8 && angle >= 0 && angle <= 180) {
       setServoAngle(motorNum - 1, angle); // Convert 1-based to 0-based index
+      recordInput();
+      server.send(200, "text/plain", "OK");
+    } else if (servoIdx != -1 && angle >= 0 && angle <= 180) {
+      setServoAngle(servoIdx, angle);
       recordInput();
       server.send(200, "text/plain", "OK");
     } else {

--- a/software/sesame-studio/sesame_studio.py
+++ b/software/sesame-studio/sesame_studio.py
@@ -17,7 +17,7 @@ class SesameStudioApp:
             pass
         
         icon_path = os.path.join(os.path.dirname(__file__), "assets", "sesame-sticker2.png")
-        if os.path.exists(icon_path):
+        if os.name == "nt" and os.path.exists(icon_path): # this crashes on some linux
             try:
                 from PIL import Image, ImageTk
                 self.icon_photo = ImageTk.PhotoImage(Image.open(icon_path))
@@ -28,7 +28,6 @@ class SesameStudioApp:
                     self.root.iconphoto(True, self.icon_photo)
                 except Exception:
                     pass
-
         self.root.geometry("800x1300")
         self.root.configure(bg="#121212")
 
@@ -61,7 +60,7 @@ class SesameStudioApp:
         
         self.draw_robot_schematic()
         
-        self.servo_vars = []
+        self.servo_vars = {} # []
         self.create_servo_inputs()
 
         self.controls_frame = tk.Frame(self.main_frame, bg=self.bg_color)
@@ -146,10 +145,10 @@ class SesameStudioApp:
         cx, cy = 380, 180 
         
         configs = [
-            (2, cx - 100, cy - 100, "S2"), (6, cx - 220, cy - 120, "S6"), 
-            (0, cx + 100, cy - 100, "S0"), (5, cx + 220, cy - 120, "S5"), 
-            (3, cx - 100, cy + 100, "S3"), (7, cx - 220, cy + 120, "S7"), 
-            (1, cx + 100, cy + 100, "S1"), (4, cx + 220, cy + 120, "S4")  
+            ("L1", cx - 100, cy - 100, "L1"), ("L3", cx - 220, cy - 120, "L3"), 
+            ("R1", cx + 100, cy - 100, "R1"), ("R3", cx + 220, cy - 120, "R3"), 
+            ("L2", cx - 100, cy + 100, "L2"), ("L4", cx - 220, cy + 120, "L4"), 
+            ("R2", cx + 100, cy + 100, "R2"), ("R4", cx + 220, cy + 120, "R4")  
         ]
         
         self.servo_colors = {
@@ -164,7 +163,7 @@ class SesameStudioApp:
         }
 
 
-        self.servo_vars = [None] * 8
+        self.servo_vars = {} # [None] * 8
 
         for s_id, x, y, label in configs:
             f = tk.Frame(self.canvas, bg="#000000")
@@ -197,23 +196,32 @@ class SesameStudioApp:
             command_str = f"setServoAngle({servo_idx}, {angle}); "
             self.code_text.insert(tk.END, command_str, f"servo_{servo_idx}")
 
-        for i in range(4):
+        for i in ["R1","L2"]:
             try:
                 val = int(self.servo_vars[i].get())
-                if val < 0 or val > 180: raise ValueError
+                if val < 45 or val > 180: raise ValueError
                 insert_command(i, val)
             except ValueError:
-                messagebox.showerror("Error", f"Invalid angle for Servo {i}")
+                messagebox.showerror("Error", f"Invalid angle for Servo {i}, range is 45 - 180")
                 return
-        self.code_text.insert(tk.END, "\n")
         
-        for i in range(4, 8):
+        for i in ["R2","L1"]:
+            try:
+                val = int(self.servo_vars[i].get())
+                if val < 0 or val > 135: raise ValueError
+                insert_command(i, val)
+            except ValueError:
+                messagebox.showerror("Error", f"Invalid angle for Servo {i}, range is 0 - 135")
+                return
+        
+        self.code_text.insert(tk.END, "\n")
+        for i in ["R3","R4","L3","L4"]:
             try:
                 val = int(self.servo_vars[i].get())
                 if val < 0 or val > 180: raise ValueError
                 insert_command(i, val)
             except ValueError:
-                messagebox.showerror("Error", f"Invalid angle for Servo {i}")
+                messagebox.showerror("Error", f"Invalid angle for Servo {i}, range is 0 - 180")
                 return
         self.code_text.insert(tk.END, "\n")
         
@@ -271,4 +279,5 @@ class SesameStudioApp:
 if __name__ == "__main__":
     root = tk.Tk()
     app = SesameStudioApp(root)
+    print("Debug: Setup")
     root.mainloop()


### PR DESCRIPTION
Name aliases (R1,L1 etc) for the 8 servos.
All movements converted to using the aliases and Studio changed to output code with aliases.
Stricter angle limits (45-180 or 0-135) for body servos and improved error messages.
Fix for Studio on linux (no icon support).
Webapi "motor" arguments also supports alias-strings.