### PR TITLE
fix uint8_t typo

### DIFF
--- a/firmware/movement-sequences.h
+++ b/firmware/movement-sequences.h
@@ -2,7 +2,7 @@
 
 #include <Arduino.h>
 
-enum ServoName : uint_8t {
+enum ServoName : uint8_t {
   R1 = 0, 
   R2 = 1,
   L1 = 2,
@@ -429,3 +429,4 @@ inline void runTurnRight() {
   }
   runStandPose(1);
 }
+


### PR DESCRIPTION
It fixes the uint8_t typo.
Apart from this, the code doesn't compile at the moment (from Arduino IDE). So I think there are a couple other errors.