### PR TITLE
Add serial command for OLED face updates

### DIFF
--- a/firmware/sesame-firmware-main.ino
+++ b/firmware/sesame-firmware-main.ino
@@ -542,6 +542,17 @@ void loop() {
         else if(strcmp(command_buffer, "rn sg") == 0) { currentCommand = "shrug"; runShrugPose(); }
         else if(strcmp(command_buffer, "rn dd") == 0) { currentCommand = "dead"; runDeadPose(); }
         else if(strcmp(command_buffer, "rn cb") == 0) { currentCommand = "crab"; runCrabPose(); }
+        else if (strncmp(command_buffer, "face ", 5) == 0 || strncmp(command_buffer, "fc ", 3) == 0) {
+          const char* faceName = (command_buffer[1] == 'c') ? command_buffer + 3 : command_buffer + 5;
+          if (strlen(faceName) > 0) {
+            currentCommand = "";
+            setFace(String(faceName));
+            Serial.print("Face set to ");
+            Serial.println(faceName);
+          } else {
+            Serial.println("Usage: face <name>");
+          }
+        }
         else if (strcmp(command_buffer, "subtrim") == 0 || strcmp(command_buffer, "st") == 0) {
           Serial.println("Subtrim values:");
           for (int i = 0; i < 8; i++) {


### PR DESCRIPTION
## Summary
- add USB Serial CLI support for `face <name>` and `fc <name>`
- clear any current motion command before applying the requested face
- reuse the existing `setFace` face registry used by the HTTP API

## Context
The firmware already supports face-only changes through `POST /api/command`, but the Serial CLI only exposes motion/debug commands. This adds parity for tethered serial clients, including Android/Termux USB-OTG workflows where Wi-Fi should remain on the user's normal network.

## Testing
- Not compiled locally; change is limited to the existing Serial CLI parser.
- Verified on hardware with current firmware that USB Serial transport works by sending `subtrim` and receiving the subtrim dump. The new face command still needs a firmware flash/hardware smoke test.